### PR TITLE
enable rustc optimizations

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ vector_grow_c: vector_grow_c.o
 vector_grow_cpp: vector_grow_cpp.cpp
 
 vector_grow_rust:
-	rustc --cfg ndebug --opt-level 3 --debuginfo 0 vector_grow_rust.rs
+	rustc --opt-level 3 --cfg ndebug -C lto -C target-cpu=corei7-avx vector_grow_rust.rs
 
 .java.class:
 	javac -Xlint $<

--- a/vector_grow_rust.rs
+++ b/vector_grow_rust.rs
@@ -7,7 +7,7 @@ use std::iter;
 
 fn main() {
     let args = os::args();
-    let n: uint = from_str(args[1].as_slice()).expect("Bad argv");
+    let n: u32 = from_str(args[1].as_slice()).expect("Bad argv");
     let mut v = Vec::new();
     let mut m = Vec::with_capacity(101);
 
@@ -23,6 +23,6 @@ fn main() {
     println!("\"size\",\"time\"");
     for (i, t) in m.iter().enumerate() {
         let time = t.to_f32().expect("Bad float conversion")/1000000000.0;
-        println!("{},{}", i * (n / 100), time);
+        println!("{},{}", i * (n as uint / 100), time);
     }
 }


### PR DESCRIPTION
You benchmarked with a debug build, and used u64 in rust but u32 everywhere else. That's just plain not fair.
