### PR TITLE
Make rust count vector fixed sized instead of dynamic

### DIFF
--- a/vector_grow_rust.rs
+++ b/vector_grow_rust.rs
@@ -9,15 +9,14 @@ fn main() {
     let args = os::args();
     let n: uint = from_str(args[1].as_slice()).expect("Bad argv");
     let mut v = Vec::new();
-    let mut m = Vec::with_capacity(101);
+    let mut m: [u64, ..101] = [0, ..101];
 
     let t = time::precise_time_ns();
-    m.push(0);
-    for _i in iter::range_step(0, n, n/100) {
+    for i in iter::range_step(0, n, n/100) {
         for j in range(0, n/100) {
             v.push(j);
         }
-        m.push(time::precise_time_ns() - t);
+        m[i / (n / 100) + 1] = time::precise_time_ns() - t;
     }
 
     println!("\"size\",\"time\"");


### PR DESCRIPTION
This reflects the other languages better and made it slightly faster on my machine.
